### PR TITLE
fix: getByUserById to take tenantIdentifier instead of appIdentifier

### DIFF
--- a/src/main/java/io/supertokens/pluginInterface/emailpassword/EmailPasswordStorage.java
+++ b/src/main/java/io/supertokens/pluginInterface/emailpassword/EmailPasswordStorage.java
@@ -34,7 +34,7 @@ public interface EmailPasswordStorage extends AuthRecipeStorage {
     // this deletion of a user is app wide since the same user ID can be shared across tenants
     void deleteEmailPasswordUser(AppIdentifier appIdentifier, String userId) throws StorageQueryException;
     
-    UserInfo getUserInfoUsingId(TenantIdentifier tenantIdentifier, String id) throws StorageQueryException;
+    UserInfo getUserInfoUsingId(AppIdentifier appIdentifier, String id) throws StorageQueryException;
 
     // Here we pass in TenantIdentifier cause the same email can be shared across tenants, but yield different
     // user IDs

--- a/src/main/java/io/supertokens/pluginInterface/emailpassword/EmailPasswordStorage.java
+++ b/src/main/java/io/supertokens/pluginInterface/emailpassword/EmailPasswordStorage.java
@@ -34,7 +34,7 @@ public interface EmailPasswordStorage extends AuthRecipeStorage {
     // this deletion of a user is app wide since the same user ID can be shared across tenants
     void deleteEmailPasswordUser(AppIdentifier appIdentifier, String userId) throws StorageQueryException;
     
-    UserInfo getUserInfoUsingId(AppIdentifier appIdentifier, String id) throws StorageQueryException;
+    UserInfo getUserInfoUsingId(TenantIdentifier tenantIdentifier, String id) throws StorageQueryException;
 
     // Here we pass in TenantIdentifier cause the same email can be shared across tenants, but yield different
     // user IDs

--- a/src/main/java/io/supertokens/pluginInterface/emailpassword/sqlStorage/EmailPasswordSQLStorage.java
+++ b/src/main/java/io/supertokens/pluginInterface/emailpassword/sqlStorage/EmailPasswordSQLStorage.java
@@ -22,6 +22,7 @@ import io.supertokens.pluginInterface.emailpassword.UserInfo;
 import io.supertokens.pluginInterface.emailpassword.exceptions.DuplicateEmailException;
 import io.supertokens.pluginInterface.exceptions.StorageQueryException;
 import io.supertokens.pluginInterface.multitenancy.AppIdentifier;
+import io.supertokens.pluginInterface.multitenancy.TenantIdentifier;
 import io.supertokens.pluginInterface.sqlStorage.SQLStorage;
 import io.supertokens.pluginInterface.sqlStorage.TransactionConnection;
 
@@ -46,6 +47,6 @@ public interface EmailPasswordSQLStorage extends EmailPasswordStorage, SQLStorag
                                       String email)
             throws StorageQueryException, DuplicateEmailException;
 
-    UserInfo getUserInfoUsingId_Transaction(AppIdentifier appIdentifier, TransactionConnection con, String userId)
+    UserInfo getUserInfoUsingId_Transaction(TenantIdentifier tenantIdentifier, TransactionConnection con, String userId)
             throws StorageQueryException;
 }

--- a/src/main/java/io/supertokens/pluginInterface/emailpassword/sqlStorage/EmailPasswordSQLStorage.java
+++ b/src/main/java/io/supertokens/pluginInterface/emailpassword/sqlStorage/EmailPasswordSQLStorage.java
@@ -47,6 +47,6 @@ public interface EmailPasswordSQLStorage extends EmailPasswordStorage, SQLStorag
                                       String email)
             throws StorageQueryException, DuplicateEmailException;
 
-    UserInfo getUserInfoUsingId_Transaction(TenantIdentifier tenantIdentifier, TransactionConnection con, String userId)
+    UserInfo getUserInfoUsingId_Transaction(AppIdentifier appIdentifier, TransactionConnection con, String userId)
             throws StorageQueryException;
 }


### PR DESCRIPTION
## Summary of change

Using tenantIdentifier for getting user by id, to avoid cross-tenant requests.

## Related issues
- Link to issue1 here
- Link to issue1 here

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] Changes to the version if needed
   - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2