### PR TITLE
Fix/active users throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 - Introduce TOTP Recipe plugin interface
+- Introduce Active users storage plugin interface
+
 ## [2.20.0] - 2023-02-21
 
 - Dashboard Recipe Interface

--- a/src/main/java/io/supertokens/pluginInterface/ActiveUsersStorage.java
+++ b/src/main/java/io/supertokens/pluginInterface/ActiveUsersStorage.java
@@ -1,9 +1,11 @@
 package io.supertokens.pluginInterface;
 
+import io.supertokens.pluginInterface.exceptions.StorageQueryException;
+
 public interface ActiveUsersStorage extends Storage {
     /* Update the last active time of a user to now */
-    void updateLastActive(String userId);
+    void updateLastActive(String userId) throws StorageQueryException;
 
     /* Count the number of users who did some activity after given timestamp */
-    int countUsersActiveSince(long time);
+    int countUsersActiveSince(long time) throws StorageQueryException;
 }

--- a/src/main/java/io/supertokens/pluginInterface/ActiveUsersStorage.java
+++ b/src/main/java/io/supertokens/pluginInterface/ActiveUsersStorage.java
@@ -1,0 +1,9 @@
+package io.supertokens.pluginInterface;
+
+public interface ActiveUsersStorage extends Storage {
+    /* Update the last active time of a user to now */
+    void updateLastActive(String userId);
+
+    /* Count the number of users who did some activity after given timestamp */
+    int countUsersActiveSince(long time);
+}


### PR DESCRIPTION
## Summary of change

Active users DB should throw query exceptions but it should get suppressed later.

## Related issues
- https://github.com/supertokens/supertokens-core/pull/585
- https://github.com/supertokens/supertokens-plugin-interface/pull/62

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] Changes to the version if needed
   - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
