### PR TITLE
fix: Active user storage to extend NonAuthStorage

### DIFF
--- a/src/main/java/io/supertokens/pluginInterface/ActiveUsersStorage.java
+++ b/src/main/java/io/supertokens/pluginInterface/ActiveUsersStorage.java
@@ -2,8 +2,9 @@ package io.supertokens.pluginInterface;
 
 import io.supertokens.pluginInterface.exceptions.StorageQueryException;
 import io.supertokens.pluginInterface.multitenancy.AppIdentifier;
+import io.supertokens.pluginInterface.nonAuthRecipe.NonAuthRecipeStorage;
 
-public interface ActiveUsersStorage extends Storage {
+public interface ActiveUsersStorage extends NonAuthRecipeStorage {
     /* Update the last active time of a user to now */
     void updateLastActive(AppIdentifier appIdentifier, String userId) throws StorageQueryException;
 


### PR DESCRIPTION
## Summary of change
(A few sentences about this PR)

## Related issues
- Link to issue1 here
- Link to issue1 here

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] Changes to the version if needed
   - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2