### PR TITLE
fix: query user with linked account from older CDI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.0.4] - 2023-11-28
+
+- Removes the error `Please use a CDI version that is greater than the one in which account linking feature was enabled` while querying users with linked accounts, but from an older version of CDI. We return details of the oldest login method in this case.
+
 ## [4.0.3] - 2023-11-10
 
 - Adds function to update userId to externalUserId for email verification

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
 }
 
-version = "4.0.3"
+version = "4.0.4"
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/supertokens/pluginInterface/authRecipe/AuthRecipeUserInfo.java
+++ b/src/main/java/io/supertokens/pluginInterface/authRecipe/AuthRecipeUserInfo.java
@@ -207,11 +207,12 @@ public class AuthRecipeUserInfo {
         if (!didCallSetExternalUserId) {
             throw new RuntimeException("Found a bug: Did you forget to call setExternalUserId?");
         }
-        // this is for older CDI versions.
         if (this.loginMethods.length != 1) {
-            throw new IllegalStateException(
-                    "Please use a CDI version that is greater than the one in which account linking feature was " +
-                            "enabled.");
+            // this is for older CDI versions.
+            // we are deliberately not throwing this exception to let the core work with older versions of CDI.
+            // throw new IllegalStateException(
+            //         "Please use a CDI version that is greater than the one in which account linking feature was " +
+            //                 "enabled.");
         }
         LoginMethod loginMethod = loginMethods[0];
         JsonObject jsonObject = new JsonObject();


### PR DESCRIPTION
## Summary of change

Removes the error `Please use a CDI version that is greater than the one in which account linking feature was enabled` while querying users with linked accounts, but from an older version of CDI. We return details of the oldest login method in this case.

## Related issues
- Link to issue1 here
- Link to issue1 here

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] Changes to the version if needed
   - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2