### PR TITLE
feat: Add support to update the signing key type of a session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Adds `createdAt` field to `TOTPDevice`
 - TOTPSQLStorage interface changes
   - Adds `getDeviceByName_Transaction` and `createDevice_Transaction` functions
+- Adds a new `useStaticKey` param to `updateSessionInfo_Transaction`
+  - This enables smooth switching between `useDynamicAccessTokenSigningKey` settings by allowing refresh calls to
+    change the signing key type of a session
 
 ## [4.0.5] - 2023-12-05
 

--- a/src/main/java/io/supertokens/pluginInterface/session/noSqlStorage/SessionNoSQLStorage_1.java
+++ b/src/main/java/io/supertokens/pluginInterface/session/noSqlStorage/SessionNoSQLStorage_1.java
@@ -47,5 +47,5 @@ public interface SessionNoSQLStorage_1 extends SessionStorage, NoSQLStorage_1 {
     SessionInfoWithLastUpdated getSessionInfo_Transaction(String sessionHandle) throws StorageQueryException;
 
     boolean updateSessionInfo_Transaction(String sessionHandle, String refreshTokenHash2, long expiry,
-            String lastUpdatedSign) throws StorageQueryException;
+            String lastUpdatedSign, boolean useStaticKey) throws StorageQueryException;
 }

--- a/src/main/java/io/supertokens/pluginInterface/session/sqlStorage/SessionSQLStorage.java
+++ b/src/main/java/io/supertokens/pluginInterface/session/sqlStorage/SessionSQLStorage.java
@@ -54,7 +54,7 @@ public interface SessionSQLStorage extends SessionStorage, SQLStorage {
 
     void updateSessionInfo_Transaction(TenantIdentifier tenantIdentifier, TransactionConnection con,
                                        String sessionHandle, String refreshTokenHash2,
-                                       long expiry) throws StorageQueryException;
+                                       long expiry, boolean useStaticKey) throws StorageQueryException;
 
     void deleteSessionsOfUser_Transaction(TransactionConnection con, AppIdentifier appIdentifier, String userId)
             throws StorageQueryException;


### PR DESCRIPTION
## Summary of change

Add support to update the signing key type of a session

## Related issues

- core: https://github.com/supertokens/supertokens-core/pull/909
- plugin-interface: https://github.com/supertokens/supertokens-plugin-interface/pull/136
- postgresql-plugin: https://github.com/supertokens/supertokens-postgresql-plugin/pull/180
- mysql-plugin: https://github.com/supertokens/supertokens-mysql-plugin/pull/88
- mongodb-plugin: https://github.com/supertokens/supertokens-mongodb-plugin/pull/31
- node: https://github.com/supertokens/supertokens-node/pull/782

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] Changes to the version if needed
   - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2