### PR TITLE
feat: fix CanBecomePrimaryResult typo

### DIFF
--- a/src/main/java/io/supertokens/pluginInterface/authRecipe/CanBecomePrimaryResult.java
+++ b/src/main/java/io/supertokens/pluginInterface/authRecipe/CanBecomePrimaryResult.java
@@ -35,7 +35,7 @@ public class CanBecomePrimaryResult {
         return new CanBecomePrimaryResult(RESULT.OK, null, null);
     }
 
-    public static CanBecomePrimaryResult wasAlreadyAPrimeryUserResult() {
+    public static CanBecomePrimaryResult wasAlreadyAPrimaryUserResult() {
         return new CanBecomePrimaryResult(RESULT.WAS_ALREADY_A_PRIMARY_USER, null, null);
     }
 


### PR DESCRIPTION
## Summary

- Fix `wasAlreadyAPrimeryUserResult` → `wasAlreadyAPrimaryUserResult` typo in `CanBecomePrimaryResult`
- Remove redundant `primaryUser` param from `removeAccountInfoReservationForPrimaryUserForUnlinking_Transaction`

**Part of the transaction isolation migration (READ COMMITTED).** Companion PRs:
- supertokens/supertokens-core — InMemoryDB implementation + core logic
- supertokens/supertokens-postgresql-plugin — PostgreSQL implementation + tests

## Test plan
- [ ] Interface-only changes; verified by compilation across all three repos
- [ ] Full PG plugin test suite running (companion PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)