### PR TITLE
fix: add bucketed active-user count to ActiveUsersStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Adds `countUsersActiveSinceGroupedByDay` function to `ActiveUsersStorage` to count active users bucketed by
+  whole days since last activity in a single query
+
 ## [8.6.1]
 
 - Adds `ActivityLogStorage` interface and `AuditLogEvent` class to support activity logging in the plugin interface.

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
 }
 
-version = "8.6.1"
+version = "8.7.0"
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/supertokens/pluginInterface/ActiveUsersStorage.java
+++ b/src/main/java/io/supertokens/pluginInterface/ActiveUsersStorage.java
@@ -18,6 +18,10 @@ public interface ActiveUsersStorage extends NonAuthRecipeStorage {
      * after sinceTime. Key = days ago (0 = within the last 24h), value = number of users in that
      * bucket. Callers that need "active since N days ago" series values take the running total of
      * buckets 0..N-1 - one query instead of one per threshold.
+     *
+     * Rows with last_active_time > now (clock skew) are not expected to occur; implementations may
+     * return them under negative keys rather than clamping to bucket 0, and callers must ignore any
+     * keys outside the 0..N-1 range they consume.
      */
     Map<Integer, Integer> countUsersActiveSinceGroupedByDay(AppIdentifier appIdentifier, long sinceTime, long now)
             throws StorageQueryException;

--- a/src/main/java/io/supertokens/pluginInterface/ActiveUsersStorage.java
+++ b/src/main/java/io/supertokens/pluginInterface/ActiveUsersStorage.java
@@ -4,12 +4,23 @@ import io.supertokens.pluginInterface.exceptions.StorageQueryException;
 import io.supertokens.pluginInterface.multitenancy.AppIdentifier;
 import io.supertokens.pluginInterface.nonAuthRecipe.NonAuthRecipeStorage;
 
+import java.util.Map;
+
 public interface ActiveUsersStorage extends NonAuthRecipeStorage {
     /* Update the last active time of a user to now */
     void updateLastActive(AppIdentifier appIdentifier, String userId) throws StorageQueryException;
 
     /* Count the number of users who did some activity after given timestamp */
     int countUsersActiveSince(AppIdentifier appIdentifier, long time) throws StorageQueryException;
+
+    /*
+     * Bucket users by how many whole days ago they were last active, counting only activity at or
+     * after sinceTime. Key = days ago (0 = within the last 24h), value = number of users in that
+     * bucket. Callers that need "active since N days ago" series values take the running total of
+     * buckets 0..N-1 - one query instead of one per threshold.
+     */
+    Map<Integer, Integer> countUsersActiveSinceGroupedByDay(AppIdentifier appIdentifier, long sinceTime, long now)
+            throws StorageQueryException;
 
     int countUsersThatHaveMoreThanOneLoginMethodAndActiveSince(AppIdentifier appIdentifier, long sinceTime)
             throws StorageQueryException;


### PR DESCRIPTION
## Problem

`GET /appid-<app>/ee/featureflag` recomputes `getPaidFeatureStats()` on every call (only
`getEnabledFeatures` is cached). The dominant cost is `getMAUs()`, which issues **31 sequential
`COUNT(*)` queries** - one per day threshold - each on its own pooled connection:

```sql
SELECT COUNT(*) FROM user_last_active WHERE app_id = ? AND last_active_time >= ?
```

The 31 queries overlap almost entirely (the 31-day query re-counts everything the 1-day query
counted), and `user_last_active` has no `(app_id, last_active_time)` index - only `(app_id)`, the PK,
and a time-leading `(last_active_time DESC, app_id DESC)` - so they degrade to sequential scans.

`EXPLAIN (ANALYZE, BUFFERS)` on eight production databases (114k-628k rows in `user_last_active`):
each count costs 46-579 ms and the 31-query loop accounts for the endpoint's full 1.4-3 s response
time. It is polled on a fixed schedule, so this runs continuously on every shared core.

Separately: the index DDL for `user_last_active` only ever runs inside
`if (!doesTableExists(...))`, so **databases created before an index was introduced never receive
it**. Of the eight databases inspected, none had the composite index and six had no
`last_active_time` index at all.

## Change

**`ActiveUsersStorage`** (internal interface): add
`countUsersActiveSinceGroupedByDay(appIdentifier, sinceTime, now)` returning
`Map<daysAgo, userCount>`.

**postgresql-plugin**
- `ActiveUsersQueries.countUsersActiveSinceGroupedByDay`: one bounded query
  ```sql
  SELECT FLOOR((? - last_active_time) / 86400000) AS days_ago, COUNT(*)
    FROM user_last_active WHERE app_id = ? AND last_active_time >= ? GROUP BY days_ago
  ```
- New index `user_last_active_app_id_last_active_time_index (app_id, last_active_time)`.
- `GeneralQueries` now also emits that index for **already existing** tables. These statements are
  deliberately kept **out of** the main `executeDDLBatch` list: that batch runs in a single
  transaction and rolls back on any failure, so a slow index build hitting a lock/statement timeout
  would abort table creation and prevent startup. A new `executeBackfillIndexDDL` runs each statement
  in its own autocommit transaction and logs failures instead of throwing - a missing index degrades
  performance but does not break correctness, and the next start retries.

**core**
- `EEFeatureFlag.getMAUs()`: one call plus a running total. `maus[i]` (users active since
  `now - (i+1) days`) is by definition the cumulative sum of buckets `0..i`, so the output array is
  identical.
- `inmemorydb` implements the new method (derives buckets from the existing count API).
- `getSAMLStats()` bug fixes: `stat.add(tenantId, stat)` added the object **to itself** (a JSON
  serialization recursion hazard for SAML-enabled apps), and `tenantStat` was never appended to
  `tenantStats`, so `"tenants"` was always an empty array.

## Measured effect

The bucketed query costs about the same as a **single** 31-day count on every database inspected
(e.g. 493 ms vs 424 ms on the largest, 180 ms vs 180 ms, 67 ms vs 49 ms), i.e. roughly a 20-30x
reduction in database work per poll, plus 31 -> 1 connection acquisitions.

## Rollout note

On large tables the index build blocks writes for its duration. Recommended: create it out of band
first with `CREATE INDEX CONCURRENTLY IF NOT EXISTS user_last_active_app_id_last_active_time_index ON
user_last_active (app_id, last_active_time);` on the biggest databases, then deploy.

## Testing

- The `maus` array from `/ee/featureflag` must be identical before and after (pure refactor of the
  same counts) - diff the arrays on a database with activity.
- `\d user_last_active` shows the new index after start.
- For a SAML-enabled app, `usageStats.saml.tenants` is now populated (was always `[]`).

## Merge order

`supertokens-plugin-interface` first, then `supertokens-postgresql-plugin`, then `supertokens-core`.
